### PR TITLE
Fix stdin errors

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -33,6 +33,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   shared_dir = "/vagrant"
 
+  config.vm.provision "fix-no-tty", type: "shell" do |s|
+    s.privileged = false
+    s.inline = "sudo sed -i '/tty/!s/mesg n/tty -s \\&\\& mesg n/' /root/.profile"
+  end
+
   config.vm.provision :shell, path: "./scripts/bootstrap.sh", :args => shared_dir
   config.vm.provision :shell, path: "./scripts/fits.sh", :args => shared_dir
   config.vm.provision :shell, path: "./scripts/fcrepo.sh", :args => shared_dir

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -33,11 +33,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   shared_dir = "/vagrant"
 
-  config.vm.provision "fix-no-tty", type: "shell" do |s|
-    s.privileged = false
-    s.inline = "sudo sed -i '/tty/!s/mesg n/tty -s \\&\\& mesg n/' /root/.profile"
-  end
-
+  config.vm.provision :shell, inline: "sudo sed -i '/tty/!s/mesg n/tty -s \\&\\& mesg n/' /root/.profile", :privileged =>false
   config.vm.provision :shell, path: "./scripts/bootstrap.sh", :args => shared_dir
   config.vm.provision :shell, path: "./scripts/fits.sh", :args => shared_dir
   config.vm.provision :shell, path: "./scripts/fcrepo.sh", :args => shared_dir

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -17,6 +17,9 @@ if [ ! -d "$HOME_DIR/git" ]; then
   mkdir git
 fi
 
+# Set apt-get for noninteractive mode
+export DEBIAN_FRONTEND=noninteractive
+
 # Update
 apt-get -y update && apt-get -y upgrade
 
@@ -30,15 +33,15 @@ apt-get -y install build-essential automake libtool
 apt-get -y install git vim
 
 # Java (Oracle)
-sudo apt-get install -y software-properties-common
-sudo apt-get install -y python-software-properties
-sudo add-apt-repository -y ppa:webupd8team/java
-sudo apt-get update
-echo debconf shared/accepted-oracle-license-v1-1 select true | sudo debconf-set-selections
-echo debconf shared/accepted-oracle-license-v1-1 seen true | sudo debconf-set-selections
-sudo apt-get install -y oracle-java8-installer
-sudo update-java-alternatives -s java-8-oracle
-sudo apt-get install -y oracle-java8-set-default
+apt-get install -y software-properties-common
+apt-get install -y python-software-properties
+add-apt-repository -y ppa:webupd8team/java
+apt-get update
+echo debconf shared/accepted-oracle-license-v1-1 select true | debconf-set-selections
+echo debconf shared/accepted-oracle-license-v1-1 seen true | debconf-set-selections
+apt-get install -y oracle-java8-installer
+update-java-alternatives -s java-8-oracle
+apt-get install -y oracle-java8-set-default
 
 # Maven
 apt-get -y install maven
@@ -73,4 +76,4 @@ echo "GRANT ALL ON fedora3.* TO 'fedoraAdmin'@'localhost'" | mysql -uroot -pisla
 echo "flush privileges" | mysql -uroot -pislandora
 
 # Add vagrant user to Apache user's group
-sudo usermod -a -G www-data vagrant
+usermod -a -G www-data vagrant

--- a/scripts/ffmpeg.sh
+++ b/scripts/ffmpeg.sh
@@ -7,10 +7,10 @@ if [ -f "$SHARED_DIR/config" ]; then
 fi
 
 # Setup libfaac dependency
-sudo sed -i '/^# deb.*multiverse/ s/^# //' /etc/apt/sources.list && sudo apt-get update && sudo apt-get install libfaac-dev -y --force-yes
+sed -i '/^# deb.*multiverse/ s/^# //' /etc/apt/sources.list && apt-get update && apt-get install libfaac-dev -y --force-yes
 
 # Install dependencies
-sudo apt-get install autoconf automake build-essential libass-dev libfreetype6-dev libgpac-dev libsdl1.2-dev libtheora-dev libtool libva-dev libvdpau-dev libvorbis-dev libx11-dev libxext-dev libxfixes-dev pkg-config texi2html zlib1g-dev yasm libx264-dev libmp3lame-dev unzip x264 libgsm1-dev libopencore-amrnb-dev libopencore-amrwb-dev libopenjpeg-dev libschroedinger-dev libspeex-dev libvpx-dev libxvidcore-dev libdc1394-22-dev -y --force-yes
+apt-get install autoconf automake build-essential libass-dev libfreetype6-dev libgpac-dev libsdl1.2-dev libtheora-dev libtool libva-dev libvdpau-dev libvorbis-dev libx11-dev libxext-dev libxfixes-dev pkg-config texi2html zlib1g-dev yasm libx264-dev libmp3lame-dev unzip x264 libgsm1-dev libopencore-amrnb-dev libopencore-amrwb-dev libopenjpeg-dev libschroedinger-dev libspeex-dev libvpx-dev libxvidcore-dev libdc1394-22-dev -y --force-yes
 
 # Download FFmpeg
 if [ ! -f "$DOWNLOAD_DIR/ffmpeg-$FFMPEG_VERSION.tar.gz" ]; then
@@ -22,4 +22,4 @@ cp "$DOWNLOAD_DIR/ffmpeg-$FFMPEG_VERSION.tar.gz" /tmp
 tar -xzvf ffmpeg-$FFMPEG_VERSION.tar.gz
 
 # Compile FFmpeg
-cd ffmpeg-$FFMPEG_VERSION && ./configure --enable-gpl --enable-version3 --enable-nonfree --enable-postproc --enable-libopencore-amrnb --enable-libopencore-amrwb --enable-libdc1394 --enable-libfaac --enable-libgsm --enable-libmp3lame --enable-libopenjpeg --enable-libschroedinger --enable-libspeex --enable-libtheora --enable-libvorbis --enable-libvpx --enable-libx264 --enable-libxvid && make && sudo make install && sudo ldconfig
+cd ffmpeg-$FFMPEG_VERSION && ./configure --enable-gpl --enable-version3 --enable-nonfree --enable-postproc --enable-libopencore-amrnb --enable-libopencore-amrwb --enable-libdc1394 --enable-libfaac --enable-libgsm --enable-libmp3lame --enable-libopenjpeg --enable-libschroedinger --enable-libspeex --enable-libtheora --enable-libvorbis --enable-libvpx --enable-libx264 --enable-libxvid && make && make install && ldconfig

--- a/scripts/fits.sh
+++ b/scripts/fits.sh
@@ -10,7 +10,7 @@ fi
 if [ ! -d $FITS_HOME ]; then
   mkdir $FITS_HOME
 fi
-sudo chown vagrant:vagrant $FITS_HOME
+chown vagrant:vagrant $FITS_HOME
 
 # Download and deploy FITS
 if [ ! -f "$DOWNLOAD_DIR/fits-$FITS_VERSION.zip" ]; then

--- a/scripts/gsearch.sh
+++ b/scripts/gsearch.sh
@@ -31,7 +31,7 @@ cp -v /tmp/gsearch/FgsBuild/fromsource/fedoragsearch.war /var/lib/tomcat7/webapp
 
 # Sleep for 75 while Tomcat restart
 echo "Sleeping for 75 while Tomcat stack restarts"
-sudo chown tomcat7:tomcat7 /var/lib/tomcat7/webapps/fedoragsearch.war
+chown tomcat7:tomcat7 /var/lib/tomcat7/webapps/fedoragsearch.war
 sed -i 's#JAVA_OPTS="-Djava.awt.headless=true -Xmx128m -XX:+UseConcMarkSweepGC"#JAVA_OPTS="-Djava.awt.headless=true -Xmx1024m -XX:MaxPermSize=256m -XX:+UseConcMarkSweepGC -Dkakadu.home=/usr/local/djatoka/bin/Linux-x86-64 -Djava.library.path=/usr/local/djatoka/lib/Linux-x86-64 -DLD_LIBRARY_PATH=/usr/local/djatoka/lib/Linux-x86-64"#g' /etc/default/tomcat7
 service tomcat7 restart
 sleep 75
@@ -51,5 +51,5 @@ chown -hR tomcat7:tomcat7 /usr/local/solr
 chown -hR tomcat7:tomcat7 /var/lib/tomcat7/webapps/fedoragsearch
 
 # Restart Tomcat
-sudo chown tomcat7:tomcat7 /var/lib/tomcat7/webapps/fedoragsearch.war
+chown tomcat7:tomcat7 /var/lib/tomcat7/webapps/fedoragsearch.war
 service tomcat7 restart

--- a/scripts/islandora_modules.sh
+++ b/scripts/islandora_modules.sh
@@ -38,22 +38,22 @@ if [ ! -d "$HOME_DIR/.drush" ]; then
   chown vagrant:vagrant $HOME_DIR/.drush
 fi
 
-# Mov OpenSeadragon drush file to user's .drush folder
+# Move OpenSeadragon drush file to user's .drush folder
 if [ -d "$HOME_DIR/.drush" -a -f "/var/www/html/drupal/sites/all/modules/islandora_openseadragon/islandora_openseadragon.drush.inc" ]; then
   mv "/var/www/html/drupal/sites/all/modules/islandora_openseadragon/islandora_openseadragon.drush.inc" "$HOME_DIR/.drush"
 fi
 
-# Mov video.js drush file to user's .drush folder
+# Move video.js drush file to user's .drush folder
 if [ -d "$HOME_DIR/.drush" -a -f "/var/www/html/drupal/sites/all/modules/islandora_videojs/islandora_videojs.drush.inc" ]; then
   mv "/var/www/html/drupal/sites/all/modules/islandora_videojs/islandora_videojs.drush.inc" "$HOME_DIR/.drush"
 fi
 
-# Mov pdf.js drush file to user's .drush folder
+# Move pdf.js drush file to user's .drush folder
 if [ -d "$HOME_DIR/.drush" -a -f "/var/www/html/drupal/sites/all/modules/islandora_pdfjs/islandora_pdfjs.drush.inc" ]; then
   mv "/var/www/html/drupal/sites/all/modules/islandora_pdfjs/islandora_pdfjs.drush.inc" "$HOME_DIR/.drush"
 fi
 
-# Mov IA Bookreader drush file to user's .drush folder
+# Move IA Bookreader drush file to user's .drush folder
 if [ -d "$HOME_DIR/.drush" -a -f "/var/www/html/drupal/sites/all/modules/islandora_internet_archive_bookreader/islandora_internet_archive_bookreader.drush.inc" ]; then
   mv "/var/www/html/drupal/sites/all/modules/islandora_internet_archive_bookreader/islandora_internet_archive_bookreader.drush.inc" "$HOME_DIR/.drush"
 fi

--- a/scripts/sleuthkit.sh
+++ b/scripts/sleuthkit.sh
@@ -12,4 +12,4 @@ apt-get install libafflib-dev afflib-tools libewf-dev ewf-tools -y --force-yes
 # Clone and compile Sleuthkit
 cd $HOME_DIR/git
 git clone https://github.com/sleuthkit/sleuthkit.git
-cd sleuthkit && ./bootstrap && ./configure && make && sudo make install && sudo ldconfig
+cd sleuthkit && ./bootstrap && ./configure && make && make install && ldconfig

--- a/scripts/warctools.sh
+++ b/scripts/warctools.sh
@@ -12,4 +12,4 @@ apt-get install python-setuptools python-unittest2 -y --force-yes
 # Clone and build warctools
 cd $HOME_DIR/git
 git clone https://github.com/internetarchive/warctools.git
-cd warctools && ./setup.py build && sudo ./setup.py install
+cd warctools && ./setup.py build && ./setup.py install


### PR DESCRIPTION
There are two types of harmless errors in Vagrant's output: 1) `dpkg-preconfigure: unable to re-open stdin: No such file or directory` and 2) `stdin: is not a tty`.

I've fixed them by adding the following to the bootstrap script:

```
export DEBIAN_FRONTEND=noninteractive
```

and the following to the Vagrantfile:

```
config.vm.provision "fix-no-tty", type: "shell" do |s|
  s.privileged = false
  s.inline = "sudo sed -i '/tty/!s/mesg n/tty -s \\&\\& mesg n/' /root/.profile"
end
```

I also went through and removed the sudos from the scripts that are running with privilege.  I'm a Vagrant newbie, but I think they aren't necessary in those cases (only in the cases where the script runs without privilege).  Everything seems to build fine, but if I'm missing something let me know.  Thanks.
