### PR TITLE
Add devtools used by ant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -35,6 +35,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.provision :shell, inline: "sudo sed -i '/tty/!s/mesg n/tty -s \\&\\& mesg n/' /root/.profile", :privileged =>false
   config.vm.provision :shell, path: "./scripts/bootstrap.sh", :args => shared_dir
+  config.vm.provision :shell, path: "./scripts/devtools.sh", :args => shared_dir
   config.vm.provision :shell, path: "./scripts/fits.sh", :args => shared_dir
   config.vm.provision :shell, path: "./scripts/fcrepo.sh", :args => shared_dir
   config.vm.provision :shell, path: "./scripts/djatoka.sh", :args => shared_dir

--- a/scripts/devtools.sh
+++ b/scripts/devtools.sh
@@ -1,0 +1,49 @@
+# Sets up a developer environment
+
+# Create a configuration script to help get a Git environment set up
+sudo tee /usr/local/bin/git-config > /dev/null << GIT_CONFIG_EOF
+#! /bin/bash
+
+if [ "\$#" -eq 3 ]; then
+  NAME="\$1"
+  EMAIL="\$2"
+  PUSH="\$3"
+elif [ "\$#" -eq 2 ]; then
+  NAME="\$1"
+  EMAIL="\$2"
+  PUSH="simple"
+else
+  echo 'Usage: git-config "Your Name" "your@email.com" [PUSH_DEFAULT]'
+  exit 1
+fi
+
+git config --global user.name "\$NAME"
+git config --global user.email "\$EMAIL"
+git config --global push.default "\$PUSH"
+
+GIT_CONFIG_EOF
+
+chmod 755 /usr/local/bin/git-config
+
+# Install tools used by Islandora Ant builds
+wget -q https://phar.phpunit.de/phploc.phar
+mv phploc.phar /usr/local/bin/phploc
+chmod +x /usr/local/bin/phploc
+
+wget -q https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar
+mv phpcs.phar /usr/local/bin/phpcs
+chmod +x /usr/local/bin/phpcs
+
+wget -q https://phar.phpunit.de/phpcpd.phar
+mv phpcpd.phar /usr/local/bin/phpcpd
+chmod +x /usr/local/bin/phpcpd
+
+wget -q http://static.pdepend.org/php/latest/pdepend.phar
+mv pdepend.phar /usr/local/bin/pdepend
+chmod +x /usr/local/bin/pdepend
+
+wget -q https://github.com/mayflower/PHP_CodeBrowser/releases/download/1.1.1/phpcb-1.1.1.phar
+mv phpcb-1.1.1.phar /usr/local/bin/phpcb
+chmod +x /usr/local/bin/phpcb
+
+apt-get install -y doxygen


### PR DESCRIPTION
Adds a simple (and optional) git environment script to set up user.name, user.email, and push strategy for user.

Adds PHP tools referenced in Islandora Ant build files: phploc, phploc, phpcpd, pdepend, phpcb, doxygen.
