### PR TITLE
Fix various small housekeeping issues

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -12,12 +12,7 @@ if [ ! -d "$DOWNLOAD_DIR" ]; then
   mkdir -p $DOWNLOAD_DIR
 fi
 
-cd $HOME_DIR
-if [ ! -d "$HOME_DIR/git" ]; then
-  mkdir git
-fi
-
-# Set apt-get for noninteractive mode
+# Set apt-get for non-interactive mode
 export DEBIAN_FRONTEND=noninteractive
 
 # Update

--- a/scripts/devtools.sh
+++ b/scripts/devtools.sh
@@ -46,4 +46,7 @@ wget -q https://github.com/mayflower/PHP_CodeBrowser/releases/download/1.1.1/php
 mv phpcb-1.1.1.phar /usr/local/bin/phpcb
 chmod +x /usr/local/bin/phpcb
 
+# Set apt-get for non-interactive mode
+export DEBIAN_FRONTEND=noninteractive
+
 apt-get install -y doxygen

--- a/scripts/fcrepo.sh
+++ b/scripts/fcrepo.sh
@@ -1,4 +1,4 @@
-echo "Installing Fedora."
+echo "Preparing to install Fedora."
 
 # Get shared directory from VagrantFile
 SHARED_DIR=$1
@@ -14,30 +14,26 @@ fi
 chown tomcat7:tomcat7 $FEDORA_HOME
 chmod g-w $FEDORA_HOME
 
-if [ ! -f "$DOWNLOAD_DIR/fcrepo-installer-$FEDORA_VERSION.jar" ]; then
-  echo "Downloading Fedora"
-  # Download fcrepo
-  wget -q -O "$DOWNLOAD_DIR/fcrepo-installer-$FEDORA_VERSION.jar" "http://downloads.sourceforge.net/project/fedora-commons/fedora/$FEDORA_VERSION/fcrepo-installer-$FEDORA_VERSION.jar"
-fi
+echo "Downloading Fedora"
+wget -q -O "/tmp/fcrepo-installer-$FEDORA_VERSION.jar" "http://downloads.sourceforge.net/project/fedora-commons/fedora/$FEDORA_VERSION/fcrepo-installer-$FEDORA_VERSION.jar"
 
-# Get install properties
-cd $HOME_DIR
-cp "$DOWNLOAD_DIR/fcrepo-installer-$FEDORA_VERSION.jar" $HOME_DIR
+echo "Downloading Fedora's install.properties file"
+wget -q -O "/tmp/install.properties" "https://gist.githubusercontent.com/ruebot/d7c2298f47798adb1111/raw/e7a179dca6cd12a3c60dfa6a32ba4f522c45f52b/install.properties"
 
-if [ ! -f "$DOWNLOAD_DIR/install.properties" ]; then
-  wget -O "$DOWNLOAD_DIR/install.properties" https://gist.githubusercontent.com/ruebot/d7c2298f47798adb1111/raw/e7a179dca6cd12a3c60dfa6a32ba4f522c45f52b/install.properties
-fi
+echo "Installing Fedora"
+java -jar /tmp/fcrepo-installer-$FEDORA_VERSION.jar /tmp/install.properties
 
-cp "$DOWNLOAD_DIR/install.properties" $HOME_DIR
-java -jar fcrepo-installer-$FEDORA_VERSION.jar install.properties
-
+# Check the exit code from the installation process
 if [ $? -ne 0 ]; then
   # Had a corrupt jarfile in cache, if can't install then redownload it
   echo "Problem with jar file, redownloading"
-  rm -f "$DOWNLOAD_DIR/fcrepo-installer-$FEDORA_VERSION.jar" 
-  wget -q -O "$DOWNLOAD_DIR/fcrepo-installer-$FEDORA_VERSION.jar" "http://downloads.sourceforge.net/project/fedora-commons/fedora/$FEDORA_VERSION/fcrepo-installer-$FEDORA_VERSION.jar"
-  cp "$DOWNLOAD_DIR/fcrepo-installer-$FEDORA_VERSION.jar" $HOME_DIR
-  java -jar fcrepo-installer-$FEDORA_VERSION.jar install.properties
+  wget -q -O "/tmp/fcrepo-installer-$FEDORA_VERSION.jar" "http://downloads.sourceforge.net/project/fedora-commons/fedora/$FEDORA_VERSION/fcrepo-installer-$FEDORA_VERSION.jar"
+  java -jar /tmp/fcrepo-installer-$FEDORA_VERSION.jar /tmp/install.properties
+
+  if [ $? -ne 0 ]; then
+    echo "Failed a second time to install from the Fedora jar... Can't proceed!"
+    exit 1
+  fi
 fi
 
 # Deploy fcrepo
@@ -57,12 +53,9 @@ git clone https://github.com/Islandora/islandora-xacml-policies.git islandora
 sed -i 's|<AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">0:0:0:0:0:0:0:1%.+</AttributeValue>|<AttributeValue DataType="http://www.w3.org/2001/XMLSchema#string">\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}</AttributeValue>|'  /usr/local/fedora/data/fedora-xacml-policies/repository-policies/default/deny-apim-if-not-localhost.xml
 
 # Setup Drupal filter
-cd /tmp
-if [ ! -f "$DOWNLOAD_DIR/fcrepo-drupalauthfilter-3.8.0.jar" ]; then
-  wget -q -O "$DOWNLOAD_DIR/fcrepo-drupalauthfilter-3.8.0.jar" https://github.com/Islandora/islandora_drupal_filter/releases/download/v7.1.3/fcrepo-drupalauthfilter-3.8.0.jar
-fi
-cp -v "$DOWNLOAD_DIR/fcrepo-drupalauthfilter-3.8.0.jar" /var/lib/tomcat7/webapps/fedora/WEB-INF/lib
-chown tomcat7:tomcat7 /var/lib/tomcat7/webapps/fedora/WEB-INF/lib/https://github.com/Islandora/islandora_drupal_filter/releases/download/v7.1.3/fcrepo-drupalauthfilter-3.8.0.jar
+wget -q -O "/tmp/fcrepo-drupalauthfilter-$FEDORA_VERSION.jar" https://github.com/Islandora/islandora_drupal_filter/releases/download/v7.1.3/fcrepo-drupalauthfilter-$FEDORA_VERSION.jar
+cp -v "/tmp/fcrepo-drupalauthfilter-$FEDORA_VERSION.jar" /var/lib/tomcat7/webapps/fedora/WEB-INF/lib
+chown tomcat7:tomcat7 /var/lib/tomcat7/webapps/fedora/WEB-INF/lib/fcrepo-drupalauthfilter-$FEDORA_VERSION.jar
 cd $FEDORA_HOME/server/config
 curl -O https://gist.githubusercontent.com/ruebot/8ef1fd7e5dfcbf6fa1ac/raw/c57b68767fb35d936271ba211c3d563c9b23e5e2/jaas.conf
 curl -O https://gist.githubusercontent.com/ruebot/21b991d02357da3e22c4/raw/05e39539dfba05869c14f74821a0f3305ab0e410/filter-drupal.xml

--- a/scripts/ffmpeg.sh
+++ b/scripts/ffmpeg.sh
@@ -6,6 +6,9 @@ if [ -f "$SHARED_DIR/config" ]; then
   . $SHARED_DIR/config
 fi
 
+# Set apt-get for non-interactive mode
+export DEBIAN_FRONTEND=noninteractive
+
 # Setup libfaac dependency
 sed -i '/^# deb.*multiverse/ s/^# //' /etc/apt/sources.list && apt-get update && apt-get install libfaac-dev -y --force-yes
 

--- a/scripts/gsearch.sh
+++ b/scripts/gsearch.sh
@@ -7,7 +7,7 @@ if [ -f "$SHARED_DIR/config" ]; then
 fi
 
 # Dependencies
-cd $HOME_DIR/git
+cd /tmp
 git clone https://github.com/discoverygarden/basic-solr-config.git
 cd basic-solr-config
 git checkout 4.x
@@ -15,7 +15,7 @@ cd islandora_transforms
 sed -i 's#/usr/local/fedora/tomcat#/var/lib/tomcat7#g' *xslt
 
 # dgi_gsearch_extensions
-cd $HOME_DIR/git
+cd /tmp
 git clone https://github.com/discoverygarden/dgi_gsearch_extensions.git
 cd dgi_gsearch_extensions
 mvn package
@@ -38,15 +38,15 @@ sleep 75
 
 # GSearch configurations
 cd /var/lib/tomcat7/webapps/fedoragsearch/WEB-INF/classes
-wget http://alpha.library.yorku.ca/fgsconfigFinal.zip
+wget -q http://alpha.library.yorku.ca/fgsconfigFinal.zip
 unzip fgsconfigFinal.zip
 
 # Deploy dgi_gsearch_extensions
-cp -v $HOME_DIR/git/dgi_gsearch_extensions/target/gsearch_extensions-0.1.1-jar-with-dependencies.jar /var/lib/tomcat7/webapps/fedoragsearch/WEB-INF/lib
+cp -v /tmp/dgi_gsearch_extensions/target/gsearch_extensions-0.1.1-jar-with-dependencies.jar /var/lib/tomcat7/webapps/fedoragsearch/WEB-INF/lib
 
 # Solr & GSearch configurations
-cp -v $HOME_DIR/git/basic-solr-config/conf/* /usr/local/solr/collection1/conf
-cp -Rv $HOME_DIR/git/basic-solr-config/islandora_transforms/* /var/lib/tomcat7/webapps/fedoragsearch/WEB-INF/classes/fgsconfigFinal/index/FgsIndex/islandora_transforms
+cp -v /tmp/basic-solr-config/conf/* /usr/local/solr/collection1/conf
+cp -Rv /tmp/basic-solr-config/islandora_transforms/* /var/lib/tomcat7/webapps/fedoragsearch/WEB-INF/classes/fgsconfigFinal/index/FgsIndex/islandora_transforms
 chown -hR tomcat7:tomcat7 /usr/local/solr
 chown -hR tomcat7:tomcat7 /var/lib/tomcat7/webapps/fedoragsearch
 

--- a/scripts/islandora_libraries.sh
+++ b/scripts/islandora_libraries.sh
@@ -18,3 +18,6 @@ sudo drush -v -y en islandora_openseadragon
 
 sudo chown -hR www-data:www-data /var/www/html/drupal/sites/all/libraries
 sudo chmod -R 775 /var/www/html/drupal/sites/all/libraries
+
+# After last drush call from root user, change cache permissions
+sudo chown -R vagrant:vagrant $HOME_DIR/.drush

--- a/scripts/islandora_modules.sh
+++ b/scripts/islandora_modules.sh
@@ -7,13 +7,12 @@ if [ -f "$SHARED_DIR/config" ]; then
 fi
 
 # List of Islandora Foundation modules
-cd $HOME_DIR
-wget https://raw.githubusercontent.com/ruebot/islandora-release-manager-helper-scripts/7.x-1.5/islandora-module-list-sans-tuque.txt
+wget -q -O /tmp/islandora-module-list-sans-tuque.txt https://raw.githubusercontent.com/ruebot/islandora-release-manager-helper-scripts/7.x-1.5/islandora-module-list-sans-tuque.txt
 
 # Clone all Islandora Foundation modules
 cd /var/www/html/drupal/sites/all/modules
-cat $HOME_DIR/islandora-module-list-sans-tuque.txt | while read line; do
-  git clone https://github.com/Islandora/$line
+cat /tmp/islandora-module-list-sans-tuque.txt | while read LINE; do
+  git clone https://github.com/Islandora/$LINE
 done
 
 # Clone Tuque

--- a/scripts/sleuthkit.sh
+++ b/scripts/sleuthkit.sh
@@ -6,10 +6,13 @@ if [ -f "$SHARED_DIR/config" ]; then
   . $SHARED_DIR/config
 fi
 
+# Set apt-get for non-interactive mode
+export DEBIAN_FRONTEND=noninteractive
+
 # Dependencies
 apt-get install libafflib-dev afflib-tools libewf-dev ewf-tools -y --force-yes
 
 # Clone and compile Sleuthkit
-cd $HOME_DIR/git
+cd /tmp
 git clone https://github.com/sleuthkit/sleuthkit.git
 cd sleuthkit && ./bootstrap && ./configure && make && make install && ldconfig

--- a/scripts/warctools.sh
+++ b/scripts/warctools.sh
@@ -6,10 +6,13 @@ if [ -f "$SHARED_DIR/config" ]; then
   . $SHARED_DIR/config
 fi
 
+# Set apt-get for non-interactive mode
+export DEBIAN_FRONTEND=noninteractive
+
 # Dependencies
 apt-get install python-setuptools python-unittest2 -y --force-yes
 
 # Clone and build warctools
-cd $HOME_DIR/git
+cd /tmp
 git clone https://github.com/internetarchive/warctools.git
 cd warctools && ./setup.py build && ./setup.py install


### PR DESCRIPTION
Includes several small housekeeping type things:
- Cleans up build artifacts left in $HOME by using /tmp as a scratch space instead
- Adds noninteractive build flag to other scripts too, not just bootstrap.sh
- Fixes what looks like a [copy paste error](https://github.com/Islandora-Labs/islandora_vagrant/blob/master/scripts/fcrepo.sh#L65)
- Sets quiet flag on wget(s) that didn't already have it
- Resets permission of the .drush directory after the final drush run so the .cache is owned by the 'vagrant' user instead of 'root'
