### PR TITLE
Update to using Drush Make

### DIFF
--- a/configs/islandora.drush.make
+++ b/configs/islandora.drush.make
@@ -1,0 +1,68 @@
+; Run this from within the sites/default or sites/all directory, whichever you prefer:
+; drush make --yes --no-core --contrib-destination=. islandora.drush.make 
+
+; Core version
+core = 7.x
+
+; Should always be 2.
+api = 2
+
+; Modules
+
+; Defaults that apply to all modules.
+defaults[projects][type] = "module"
+defaults[projects][download][type] = "git"
+defaults[projects][download][branch]  = "7.x"
+defaults[projects][download][overwrite] = TRUE
+
+projects[islandora][download][url] = "http://github.com/Islandora/islandora.git"
+projects[islandora_bagit][download][url] = "http://github.com/Islandora/islandora_bagit.git"
+projects[islandora_batch][download][url] = "http://github.com/Islandora/islandora_batch.git"
+projects[islandora_book_batch][download][url] = "http://github.com/Islandora/islandora_book_batch.git"
+projects[islandora_bookmark][download][url] = "http://github.com/Islandora/islandora_bookmark.git"
+projects[islandora_checksum][download][url] = "http://github.com/Islandora/islandora_checksum.git"
+projects[islandora_checksum_checker][download][url] = "http://github.com/Islandora/islandora_checksum_checker.git"
+projects[islandora_fits][download][url] = "http://github.com/Islandora/islandora_fits.git"
+projects[islandora_image_annotation][download][url] = "http://github.com/Islandora/islandora_image_annotation.git"
+projects[islandora_importer][download][url] = "http://github.com/Islandora/islandora_importer.git"
+projects[islandora_internet_archive_bookreader][download][url] = "http://github.com/Islandora/islandora_internet_archive_bookreader.git"
+projects[islandora_jwplayer][download][url] = "http://github.com/Islandora/islandora_jwplayer.git"
+projects[islandora_marcxml][download][url] = "http://github.com/Islandora/islandora_marcxml.git"
+projects[islandora_oai][download][url] = "http://github.com/Islandora/islandora_oai.git"
+projects[islandora_ocr][download][url] = "http://github.com/Islandora/islandora_ocr.git"
+projects[islandora_openseadragon][download][url] = "http://github.com/Islandora/islandora_openseadragon.git"
+projects[islandora_paged_content][download][url] = "http://github.com/Islandora/islandora_paged_content.git"
+projects[islandora_pathauto][download][url] = "http://github.com/Islandora/islandora_pathauto.git"
+projects[islandora_pdfjs][download][url] = "http://github.com/Islandora/islandora_pdfjs.git"
+projects[islandora_premis][download][url] = "http://github.com/Islandora/islandora_premis.git"
+projects[islandora_scholar][download][url] = "http://github.com/Islandora/islandora_scholar.git"
+projects[islandora_simple_workflow][download][url] = "http://github.com/Islandora/islandora_simple_workflow.git"
+projects[islandora_solr_facet_pages][download][url] = "http://github.com/Islandora/islandora_solr_facet_pages.git"
+projects[islandora_solr_metadata][download][url] = "http://github.com/Islandora/islandora_solr_metadata.git"
+projects[islandora_solr_search][download][url] = "http://github.com/Islandora/islandora_solr_search.git"
+projects[islandora_solr_views][download][url] = "http://github.com/Islandora/islandora_solr_views.git"
+projects[islandora_solution_pack_audio][download][url] = "http://github.com/Islandora/islandora_solution_pack_audio.git"
+projects[islandora_solution_pack_book][download][url] = "http://github.com/Islandora/islandora_solution_pack_book.git"
+projects[islandora_solution_pack_collection][download][url] = "http://github.com/Islandora/islandora_solution_pack_collection.git"
+projects[islandora_solution_pack_compound][download][url] = "http://github.com/Islandora/islandora_solution_pack_compound.git"
+projects[islandora_solution_pack_disk_image][download][url] = "http://github.com/Islandora/islandora_solution_pack_disk_image.git"
+projects[islandora_solution_pack_entities][download][url] = "http://github.com/Islandora/islandora_solution_pack_entities.git"
+projects[islandora_solution_pack_image][download][url] = "http://github.com/Islandora/islandora_solution_pack_image.git"
+projects[islandora_solution_pack_large_image][download][url] = "http://github.com/Islandora/islandora_solution_pack_large_image.git"
+projects[islandora_solution_pack_newspaper][download][url] = "http://github.com/Islandora/islandora_solution_pack_newspaper.git"
+projects[islandora_solution_pack_pdf][download][url] = "http://github.com/Islandora/islandora_solution_pack_pdf.git"
+projects[islandora_solution_pack_video][download][url] = "http://github.com/Islandora/islandora_solution_pack_video.git"
+projects[islandora_solution_pack_web_archive][download][url] = "http://github.com/Islandora/islandora_solution_pack_web_archive.git"
+projects[islandora_videojs][download][url] = "http://github.com/Islandora/islandora_videojs.git"
+projects[islandora_xacml_editor][download][url] = "http://github.com/Islandora/islandora_xacml_editor.git"
+projects[islandora_xml_forms][download][url] = "http://github.com/Islandora/islandora_xml_forms.git"
+projects[islandora_xmlsitemap][download][url] = "http://github.com/Islandora/islandora_xmlsitemap.git"
+projects[objective_forms][download][url] = "http://github.com/Islandora/objective_forms.git"
+projects[php_lib][download][url] = "http://github.com/Islandora/php_lib.git"
+
+; Libraries
+
+libraries[tuque][download][type] = "git"
+libraries[tuque][download][overwrite] = TRUE
+libraries[tuque][download][branch] = "1.x"
+libraries[tuque][download][url] = "http://github.com/Islandora/tuque.git"

--- a/configs/variables
+++ b/configs/variables
@@ -18,4 +18,4 @@ FITS_VERSION=0.8.5
 SOLR_HOME="/usr/local/solr"
 SOLR_VERSION=4.2.0
 
-DRUPAL_LIBRARIES="/var/www/html/drupal/sites/all/libraries"
+DRUPAL_LIBRARIES="/var/www/drupal/sites/all/libraries"

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -4,8 +4,8 @@
 
 SHARED_DIR=$1
 
-if [ -f "$SHARED_DIR/config" ]; then
-  . $SHARED_DIR/config
+if [ -f "$SHARED_DIR/configs/variables" ]; then
+  . $SHARED_DIR/configs/variables
 fi
 
 if [ ! -d "$DOWNLOAD_DIR" ]; then

--- a/scripts/devtools.sh
+++ b/scripts/devtools.sh
@@ -1,5 +1,11 @@
 # Sets up a developer environment
 
+# Set apt-get for non-interactive mode
+export DEBIAN_FRONTEND=noninteractive
+
+# Install doxygen and pear for installing PHP_CodeSniffer
+apt-get install -y php-pear doxygen
+
 # Create a configuration script to help get a Git environment set up
 sudo tee /usr/local/bin/git-config > /dev/null << GIT_CONFIG_EOF
 #! /bin/bash
@@ -50,8 +56,3 @@ tar -xzvf coder-8.x-2.1.tar.gz
 mv -v coder /usr/share
 chown -hR vagrant:vagrant /usr/share/coder
 ln -sv /usr/share/coder/coder_sniffer/Drupal /usr/share/php/PHP/CodeSniffer/Standards
-
-# Set apt-get for non-interactive mode
-export DEBIAN_FRONTEND=noninteractive
-
-apt-get install -y doxygen

--- a/scripts/djatoka.sh
+++ b/scripts/djatoka.sh
@@ -1,9 +1,8 @@
 SHARED_DIR=$1
 
-if [ -f "$SHARED_DIR/config" ]; then
-  . $SHARED_DIR/config
+if [ -f "$SHARED_DIR/configs/variables" ]; then
+  . $SHARED_DIR/configs/variables
 fi
-
 
 echo "Installing Djatoka"
 

--- a/scripts/drupal.sh
+++ b/scripts/drupal.sh
@@ -2,9 +2,12 @@ echo "Installing Drupal."
 
 SHARED_DIR=$1
 
-if [ -f "$SHARED_DIR/config" ]; then
-  . $SHARED_DIR/config
+if [ -f "$SHARED_DIR/configs/variables" ]; then
+  . $SHARED_DIR/configs/variables
 fi
+
+# Set apt-get for non-interactive mode
+export DEBIAN_FRONTEND=noninteractive
 
 # Drush and drupal deps
 apt-get -y install php5-gd php5-dev php5-xsl php-soap php5-curl php5-imagick imagemagick lame libimage-exiftool-perl bibutils poppler-utils
@@ -13,7 +16,7 @@ sed -i '/; extension_dir = "ext"/ a\ extension=uploadprogress.so' /etc/php5/apac
 apt-get -y install drush
 a2enmod rewrite
 service apache2 reload
-cd /var/www/html
+cd /var/www
 
 # Download Drupal
 drush dl drupal --drupal-project-rename=drupal
@@ -34,7 +37,7 @@ ln -s /etc/apache2/mods-available/proxy_html.load /etc/apache2/mods-enabled/prox
 ln -s /etc/apache2/mods-available/headers.load /etc/apache2/mods-enabled/headers.load
 
 # Set document root
-sed -i 's|DocumentRoot /var/www/html$|DocumentRoot /var/www/html/drupal|' /etc/apache2/sites-enabled/000-default.conf
+sed -i 's|DocumentRoot /var/www/html$|DocumentRoot /var/www/drupal|' /etc/apache2/sites-enabled/000-default.conf
 
 # Set override for drupal directory
 # Now inserting into VirtualHost container - whikloj (2015-04-30)
@@ -49,7 +52,7 @@ NameVirtualHost \*:8000' /etc/apache2/ports.conf
 
 sed -i '/<\/VirtualHost>/i \
   ServerAlias islandora-vagrant\
-  <Directory /var/www/html/drupal>\
+  <Directory /var/www/drupal>\
     Options Indexes FollowSymLinks\
     AllowOverride All\
     Require all granted\
@@ -105,8 +108,8 @@ done
 service apache2 restart
 
 # sites/default/files ownership
-chown -hR www-data:www-data /var/www/html/drupal/sites/default/files
+chown -hR www-data:www-data /var/www/drupal/sites/default/files
 
 # Run cron
-cd /var/www/html/drupal/sites/all/modules
+cd /var/www/drupal/sites/all/modules
 drush cron

--- a/scripts/fcrepo.sh
+++ b/scripts/fcrepo.sh
@@ -3,8 +3,8 @@ echo "Preparing to install Fedora."
 # Get shared directory from VagrantFile
 SHARED_DIR=$1
 
-if [ -f "$SHARED_DIR/config" ]; then
-  . $SHARED_DIR/config
+if [ -f "$SHARED_DIR/configs/variables" ]; then
+  . $SHARED_DIR/configs/variables
 fi
 
 # Prepare $FEDORA_HOME
@@ -15,10 +15,18 @@ chown tomcat7:tomcat7 $FEDORA_HOME
 chmod g-w $FEDORA_HOME
 
 echo "Downloading Fedora"
-wget -q -O "/tmp/fcrepo-installer-$FEDORA_VERSION.jar" "http://downloads.sourceforge.net/project/fedora-commons/fedora/$FEDORA_VERSION/fcrepo-installer-$FEDORA_VERSION.jar"
+if [ ! -f "$DOWNLOAD_DIR/fcrepo-installer-$FEDORA_VERSION.jar" ]; then
+  wget -q -O "/tmp/fcrepo-installer-$FEDORA_VERSION.jar" "http://downloads.sourceforge.net/project/fedora-commons/fedora/$FEDORA_VERSION/fcrepo-installer-$FEDORA_VERSION.jar"
+else
+  cp "$DOWNLOAD_DIR/fcrepo-installer-$FEDORA_VERSION.jar" "/tmp/fcrepo-installer-$FEDORA_VERSION.jar"
+fi
 
 echo "Downloading Fedora's install.properties file"
-wget -q -O "/tmp/install.properties" "https://gist.githubusercontent.com/ruebot/d7c2298f47798adb1111/raw/e7a179dca6cd12a3c60dfa6a32ba4f522c45f52b/install.properties"
+if [ ! -f "$DOWNLOAD_DIR/install.properties" ]; then
+  wget -q -O "/tmp/install.properties" "https://gist.githubusercontent.com/ruebot/d7c2298f47798adb1111/raw/e7a179dca6cd12a3c60dfa6a32ba4f522c45f52b/install.properties"
+else
+  cp "$DOWNLOAD_DIR/install.properties" "/tmp/install.properties"
+fi
 
 echo "Installing Fedora"
 java -jar /tmp/fcrepo-installer-$FEDORA_VERSION.jar /tmp/install.properties
@@ -33,6 +41,10 @@ if [ $? -ne 0 ]; then
   if [ $? -ne 0 ]; then
     echo "Failed a second time to install from the Fedora jar... Can't proceed!"
     exit 1
+  else
+    # Copy files to the downloads directory if they were successfully used
+    cp "/tmp/install.properties" "$DOWNLOAD_DIR/install.properties"
+    cp "/tmp/fcrepo-installer-$FEDORA_VERSION.jar" "$DOWNLOAD_DIR/fcrepo-installer-$FEDORA_VERSION.jar"
   fi
 fi
 

--- a/scripts/ffmpeg.sh
+++ b/scripts/ffmpeg.sh
@@ -2,8 +2,8 @@ echo "Installing FFmpeg."
 
 SHARED_DIR=$1
 
-if [ -f "$SHARED_DIR/config" ]; then
-  . $SHARED_DIR/config
+if [ -f "$SHARED_DIR/configs/variables" ]; then
+  . $SHARED_DIR/configs/variables
 fi
 
 # Set apt-get for non-interactive mode

--- a/scripts/fits.sh
+++ b/scripts/fits.sh
@@ -2,8 +2,8 @@ echo "Installing FITS"
 
 SHARED_DIR=$1
 
-if [ -f "$SHARED_DIR/config" ]; then
-  . $SHARED_DIR/config
+if [ -f "$SHARED_DIR/configs/variables" ]; then
+  . $SHARED_DIR/configs/variables
 fi
 
 # Setup FITS_HOME

--- a/scripts/gsearch.sh
+++ b/scripts/gsearch.sh
@@ -2,8 +2,8 @@ echo "Installing GSearch"
 
 SHARED_DIR=$1
 
-if [ -f "$SHARED_DIR/config" ]; then
-  . $SHARED_DIR/config
+if [ -f "$SHARED_DIR/configs/variables" ]; then
+  . $SHARED_DIR/configs/variables
 fi
 
 # Dependencies

--- a/scripts/islandora_libraries.sh
+++ b/scripts/islandora_libraries.sh
@@ -2,11 +2,11 @@ echo "Installing all Islandora Foundation module's required libraries"
 
 SHARED_DIR=$1
 
-if [ -f "$SHARED_DIR/config" ]; then
-  . $SHARED_DIR/config
+if [ -f "$SHARED_DIR/configs/variables" ]; then
+  . $SHARED_DIR/configs/variables
 fi
 
-cd /var/www/html/drupal/sites/all/modules
+cd /var/www/drupal/sites/all/modules
 
 sudo drush cache-clear drush
 sudo drush -v videojs-plugin
@@ -16,8 +16,8 @@ sudo drush -v colorbox-plugin
 sudo drush -v openseadragon-plugin
 sudo drush -v -y en islandora_openseadragon
 
-sudo chown -hR www-data:www-data /var/www/html/drupal/sites/all/libraries
-sudo chmod -R 775 /var/www/html/drupal/sites/all/libraries
+sudo chown -hR www-data:www-data /var/www/drupal/sites/all/libraries
+sudo chmod -R 775 /var/www/drupal/sites/all/libraries
 
 # After last drush call from root user, change cache permissions
 sudo chown -R vagrant:vagrant $HOME_DIR/.drush

--- a/scripts/islandora_modules.sh
+++ b/scripts/islandora_modules.sh
@@ -2,35 +2,18 @@ echo "Installing all Islandora Foundation modules"
 
 SHARED_DIR=$1
 
-if [ -f "$SHARED_DIR/config" ]; then
-  . $SHARED_DIR/config
+if [ -f "$SHARED_DIR/configs/variables" ]; then
+  . $SHARED_DIR/configs/variables
 fi
 
-# List of Islandora Foundation modules
-wget -q -O /tmp/islandora-module-list-sans-tuque.txt https://raw.githubusercontent.com/ruebot/islandora-release-manager-helper-scripts/7.x-1.5/islandora-module-list-sans-tuque.txt
+cd /var/www/drupal/sites/all
 
-# Clone all Islandora Foundation modules
-cd /var/www/html/drupal/sites/all/modules
-cat /tmp/islandora-module-list-sans-tuque.txt | while read LINE; do
-  git clone https://github.com/Islandora/$LINE
-done
+drush make --yes --no-core --contrib-destination=. $SHARED_DIR/configs/islandora.drush.make
 
-# Clone Tuque
-cd /var/www/html/drupal/sites/all
 if [ ! -d libraries ]; then
   mkdir libraries
 fi
-cd /var/www/html/drupal/sites/all/libraries
-git clone https://github.com/Islandora/tuque
 
-# Permissions and ownership
-chown -hR www-data:www-data /var/www/html/drupal/sites/all/libraries
-chown -hR www-data:www-data /var/www/html/drupal/sites/all/modules
-chmod -R 775 /var/www/html/drupal/sites/all/libraries
-chmod -R 775 /var/www/html/drupal/sites/all/modules
-
-# Enable all Islandora foundation modules
-cd /var/www/html/drupal/sites/all/modules
 # Check for a user's .drush folder, create if it doesn't exist
 if [ ! -d "$HOME_DIR/.drush" ]; then
   mkdir "$HOME_DIR/.drush"
@@ -38,46 +21,53 @@ if [ ! -d "$HOME_DIR/.drush" ]; then
 fi
 
 # Move OpenSeadragon drush file to user's .drush folder
-if [ -d "$HOME_DIR/.drush" -a -f "/var/www/html/drupal/sites/all/modules/islandora_openseadragon/islandora_openseadragon.drush.inc" ]; then
-  mv "/var/www/html/drupal/sites/all/modules/islandora_openseadragon/islandora_openseadragon.drush.inc" "$HOME_DIR/.drush"
+if [ -d "$HOME_DIR/.drush" -a -f "/var/www/drupal/sites/all/modules/islandora_openseadragon/islandora_openseadragon.drush.inc" ]; then
+  mv "/var/www/drupal/sites/all/modules/islandora_openseadragon/islandora_openseadragon.drush.inc" "$HOME_DIR/.drush"
 fi
 
 # Move video.js drush file to user's .drush folder
-if [ -d "$HOME_DIR/.drush" -a -f "/var/www/html/drupal/sites/all/modules/islandora_videojs/islandora_videojs.drush.inc" ]; then
-  mv "/var/www/html/drupal/sites/all/modules/islandora_videojs/islandora_videojs.drush.inc" "$HOME_DIR/.drush"
+if [ -d "$HOME_DIR/.drush" -a -f "/var/www/drupal/sites/all/modules/islandora_videojs/islandora_videojs.drush.inc" ]; then
+  mv "/var/www/drupal/sites/all/modules/islandora_videojs/islandora_videojs.drush.inc" "$HOME_DIR/.drush"
 fi
 
 # Move pdf.js drush file to user's .drush folder
-if [ -d "$HOME_DIR/.drush" -a -f "/var/www/html/drupal/sites/all/modules/islandora_pdfjs/islandora_pdfjs.drush.inc" ]; then
-  mv "/var/www/html/drupal/sites/all/modules/islandora_pdfjs/islandora_pdfjs.drush.inc" "$HOME_DIR/.drush"
+if [ -d "$HOME_DIR/.drush" -a -f "/var/www/drupal/sites/all/modules/islandora_pdfjs/islandora_pdfjs.drush.inc" ]; then
+  mv "/var/www/drupal/sites/all/modules/islandora_pdfjs/islandora_pdfjs.drush.inc" "$HOME_DIR/.drush"
 fi
 
 # Move IA Bookreader drush file to user's .drush folder
-if [ -d "$HOME_DIR/.drush" -a -f "/var/www/html/drupal/sites/all/modules/islandora_internet_archive_bookreader/islandora_internet_archive_bookreader.drush.inc" ]; then
-  mv "/var/www/html/drupal/sites/all/modules/islandora_internet_archive_bookreader/islandora_internet_archive_bookreader.drush.inc" "$HOME_DIR/.drush"
+if [ -d "$HOME_DIR/.drush" -a -f "/var/www/drupal/sites/all/modules/islandora_internet_archive_bookreader/islandora_internet_archive_bookreader.drush.inc" ]; then
+  mv "/var/www/drupal/sites/all/modules/islandora_internet_archive_bookreader/islandora_internet_archive_bookreader.drush.inc" "$HOME_DIR/.drush"
 fi
 
-drush -y en php_lib islandora objective_forms
-drush -y en islandora_solr islandora_solr_metadata islandora_solr_facet_pages islandora_solr_views
-drush -y en islandora_basic_collection islandora_pdf islandora_audio islandora_book islandora_compound_object islandora_disk_image islandora_entities islandora_entities_csv_import islandora_basic_image islandora_large_image islandora_newspaper islandora_video islandora_web_archive
-drush -y en islandora_premis islandora_checksum islandora_checksum_checker
-drush -y en islandora_book_batch islandora_image_annotation islandora_pathauto islandora_pdfjs islandora_videojs islandora_jwplayer
-drush -y en xml_forms xml_form_builder xml_schema_api xml_form_elements xml_form_api jquery_update zip_importer islandora_basic_image islandora_bibliography islandora_compound_object islandora_google_scholar islandora_scholar_embargo islandora_solr_config citation_exporter doi_importer endnotexml_importer pmid_importer ris_importer
-drush -y en islandora_fits islandora_ocr islandora_oai islandora_marcxml islandora_simple_workflow islandora_xacml_api islandora_xacml_editor islandora_xmlsitemap colorbox islandora_internet_archive_bookreader islandora_bagit islandora_batch_report 
+# Enable all Islandora foundation modules
+cd /var/www/drupal/sites/all/modules
+
+drush -y en php_lib islandora objective_forms islandora_solr islandora_solr_metadata islandora_solr_facet_pages \
+  islandora_solr_views islandora_basic_collection islandora_pdf islandora_audio islandora_book \
+  islandora_compound_object islandora_disk_image islandora_entities islandora_entities_csv_import \
+  islandora_basic_image  islandora_large_image islandora_newspaper islandora_video islandora_web_archive \
+  islandora_premis islandora_checksum islandora_checksum_checker islandora_book_batch islandora_image_annotation \
+  islandora_pathauto islandora_pdfjs islandora_videojs islandora_jwplayer xml_forms xml_form_builder xml_schema_api \
+  xml_form_elements xml_form_api jquery_update zip_importer islandora_basic_image islandora_bibliography \
+  islandora_compound_object islandora_google_scholar islandora_scholar_embargo islandora_solr_config citation_exporter \
+  doi_importer endnotexml_importer pmid_importer ris_importer islandora_fits islandora_ocr islandora_oai \
+  islandora_marcxml islandora_simple_workflow islandora_xacml_api islandora_xacml_editor islandora_xmlsitemap colorbox \
+  islandora_internet_archive_bookreader islandora_bagit islandora_batch_report 
 
 #BagItPHP library
-cd /var/www/html/drupal/sites/all/libraries
+cd /var/www/drupal/sites/all/libraries
 git clone git://github.com/scholarslab/BagItPHP.git
 
 # Permissions and ownership
-chown -hR www-data:www-data /var/www/html/drupal/sites/all/libraries
-chown -hR www-data:www-data /var/www/html/drupal/sites/all/modules
-chmod -R 775 /var/www/html/drupal/sites/all/libraries
-chmod -R 775 /var/www/html/drupal/sites/all/modules
+chown -hR www-data:www-data /var/www/drupal/sites/all/libraries
+chown -hR www-data:www-data /var/www/drupal/sites/all/modules
+chmod -R 775 /var/www/drupal/sites/all/libraries
+chmod -R 775 /var/www/drupal/sites/all/modules
+
+cd /var/www/drupal/sites/all/modules
 
 # Set variables for Islandora modules
-
-cd /var/www/html/drupal/sites/all/modules
 drush eval "variable_set('islandora_audio_viewers', array('name' => array('none' => 'none', 'islandora_videojs' => 'islandora_videojs'), 'default' => 'islandora_videojs'))"
 drush eval "variable_set('islandora_fits_executable_path', '/usr/local/fits/fits-0.8.4/fits.sh')"
 drush eval "variable_set('islandora_lame_url', '/usr/bin/lame')"

--- a/scripts/sleuthkit.sh
+++ b/scripts/sleuthkit.sh
@@ -2,8 +2,8 @@ echo "Installing Sleuthkit."
 
 SHARED_DIR=$1
 
-if [ -f "$SHARED_DIR/config" ]; then
-  . $SHARED_DIR/config
+if [ -f "$SHARED_DIR/configs/variables" ]; then
+  . $SHARED_DIR/configs/variables
 fi
 
 # Set apt-get for non-interactive mode

--- a/scripts/solr.sh
+++ b/scripts/solr.sh
@@ -2,8 +2,8 @@ echo "Installing Solr"
 
 SHARED_DIR=$1
 
-if [ -f "$SHARED_DIR/config" ]; then
-  . $SHARED_DIR/config
+if [ -f "$SHARED_DIR/configs/variables" ]; then
+  . $SHARED_DIR/configs/variables
 fi
 
 # Download Solr

--- a/scripts/tesseract.sh
+++ b/scripts/tesseract.sh
@@ -2,8 +2,11 @@ echo "Installing Tesseract"
 
 SHARED_DIR=$1
 
-if [ -f "$SHARED_DIR/config" ]; then
-  . $SHARED_DIR/config
+if [ -f "$SHARED_DIR/configs/variables" ]; then
+  . $SHARED_DIR/configs/variables
 fi
+
+# Set apt-get for non-interactive mode
+export DEBIAN_FRONTEND=noninteractive
 
 apt-get -y install tesseract-ocr tesseract-ocr-eng tesseract-ocr-fra

--- a/scripts/warctools.sh
+++ b/scripts/warctools.sh
@@ -2,8 +2,8 @@ echo "Installing warctools."
 
 SHARED_DIR=$1
 
-if [ -f "$SHARED_DIR/config" ]; then
-  . $SHARED_DIR/config
+if [ -f "$SHARED_DIR/configs/variables" ]; then
+  . $SHARED_DIR/configs/variables
 fi
 
 # Set apt-get for non-interactive mode


### PR DESCRIPTION
Updated islandora_modules.sh to use @mjordan's Islandora Make file (with slight changes to make it more unattended-script friendly).

Also:
- Added `DEBIAN_FRONTEND` flag on some of the scripts I apparently missed last time
- Added Pear via apt-get so PHP_CodeSniffer would install
- Renamed /var/www/html/drupal to /var/www/drupal (just one less thing to step through)
- Renamed config file to `configs/variables` to add the `configs/islandora.drush.make` file
- Added back $DOWNLOAD_DIR check for Fedora download (which I removed previously -- I realized the error of my ways and solved the issue in a slightly different way that preserves the downloaded copy)
- Lastly, removed one "Permissions and ownership" block of bash which was repeated later in the script
