### PR TITLE
Fix error associated with zsh man pages and silence curl and maven

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -52,6 +52,11 @@ sed -i 's|#JAVA_HOME=/usr/lib/jvm/openjdk-6-jdk|JAVA_HOME=/usr/lib/jvm/java-8-or
 # Wget and curl
 apt-get -y install wget curl
 
+# Bug fix for Ubuntu 14.04 with zsh 5.0.2 -- https://bugs.launchpad.net/ubuntu/+source/zsh/+bug/1242108
+export MAN_FILES=$(wget -qO- "http://sourceforge.net/projects/zsh/files/zsh/5.0.2/zsh-5.0.2.tar.gz/download" \
+  | tar xvz -C /usr/share/man/man1/ --wildcards "zsh-5.0.2/Doc/*.1" --strip-components=2)
+for MAN_FILE in $MAN_FILES; do gzip /usr/share/man/man1/${MAN_FILE##*/}; done
+
 # More helpful packages
 apt-get -y install htop tree zsh #fish
 

--- a/scripts/djatoka.sh
+++ b/scripts/djatoka.sh
@@ -41,4 +41,4 @@ sleep 30
 
 # Logging
 cd /var/lib/tomcat7/webapps/adore-djatoka/WEB-INF/classes
-curl -O https://gist.githubusercontent.com/ruebot/06abc0b8373aa2f53e4a/raw/1fd9a69d5a42bb0f10ff5fc1a57dfdd5ee28da3c/log4j.properties
+curl -sO https://gist.githubusercontent.com/ruebot/06abc0b8373aa2f53e4a/raw/1fd9a69d5a42bb0f10ff5fc1a57dfdd5ee28da3c/log4j.properties

--- a/scripts/fcrepo.sh
+++ b/scripts/fcrepo.sh
@@ -69,8 +69,8 @@ wget -q -O "/tmp/fcrepo-drupalauthfilter-$FEDORA_VERSION.jar" https://github.com
 cp -v "/tmp/fcrepo-drupalauthfilter-$FEDORA_VERSION.jar" /var/lib/tomcat7/webapps/fedora/WEB-INF/lib
 chown tomcat7:tomcat7 /var/lib/tomcat7/webapps/fedora/WEB-INF/lib/fcrepo-drupalauthfilter-$FEDORA_VERSION.jar
 cd $FEDORA_HOME/server/config
-curl -O https://gist.githubusercontent.com/ruebot/8ef1fd7e5dfcbf6fa1ac/raw/c57b68767fb35d936271ba211c3d563c9b23e5e2/jaas.conf
-curl -O https://gist.githubusercontent.com/ruebot/21b991d02357da3e22c4/raw/05e39539dfba05869c14f74821a0f3305ab0e410/filter-drupal.xml
+curl -sO https://gist.githubusercontent.com/ruebot/8ef1fd7e5dfcbf6fa1ac/raw/c57b68767fb35d936271ba211c3d563c9b23e5e2/jaas.conf
+curl -sO https://gist.githubusercontent.com/ruebot/21b991d02357da3e22c4/raw/05e39539dfba05869c14f74821a0f3305ab0e410/filter-drupal.xml
 
 # Restart Tomcat
 service tomcat7 restart

--- a/scripts/gsearch.sh
+++ b/scripts/gsearch.sh
@@ -18,7 +18,7 @@ sed -i 's#/usr/local/fedora/tomcat#/var/lib/tomcat7#g' *xslt
 cd /tmp
 git clone https://github.com/discoverygarden/dgi_gsearch_extensions.git
 cd dgi_gsearch_extensions
-mvn package
+mvn -q package
 
 # Build GSearch
 cd /tmp


### PR DESCRIPTION
Fixes a trivial problem with zsh man pages (they're missing in the LTS) and sets curl and maven to only output when there is an error.
