### PR TITLE
Add option to run a custom script from vagrantfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vagrant
 downloads
+scripts/custom.sh

--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ The default VM login details are:
 - PHP 5.5.9 
 - Java 8 (Oracle)
 
+## Customization
+
+If you'd like to add your own customization script (to install additional modules, call other scripts, etc.), you can create a "custom.sh" file in the project's "scripts" directory. When that file is present, Vagrant will run it after all the other provisioning scripts have been run.
+
 ## Authors
 
 * [Nick Ruest](https://github.com/ruebot)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -48,4 +48,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provision :shell, path: "./scripts/ffmpeg.sh", :args => shared_dir
   config.vm.provision :shell, path: "./scripts/warctools.sh", :args => shared_dir
   config.vm.provision :shell, path: "./scripts/sleuthkit.sh", :args => shared_dir
+
+  if File.exist?("./scripts/custom.sh") then
+    config.vm.provision :shell, path: "./scripts/custom.sh", :args=> shared_dir
+  end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -50,6 +50,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provision :shell, path: "./scripts/sleuthkit.sh", :args => shared_dir
 
   if File.exist?("./scripts/custom.sh") then
-    config.vm.provision :shell, path: "./scripts/custom.sh", :args=> shared_dir
+    config.vm.provision :shell, path: "./scripts/custom.sh", :args => shared_dir
   end
 end


### PR DESCRIPTION
Adds ability to create your own custom.sh script from which you can do additional installations or call other scripts.  I've also added the scripts/custom.sh file to the .gitignore file so people don't accidentally check in their local scripts.
