### PR TITLE
Set JAVA_HOME for system and prior to Tomcat install

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -38,6 +38,10 @@ apt-get install -y oracle-java8-installer
 update-java-alternatives -s java-8-oracle
 apt-get install -y oracle-java8-set-default
 
+# Set JAVA_HOME variable both now and for when the system restarts
+export JAVA_HOME=$(readlink -f /usr/bin/java | sed "s:bin/java::")
+echo "JAVA_HOME=$JAVA_HOME" >> /etc/environment
+
 # Maven
 apt-get -y install maven
 
@@ -45,9 +49,6 @@ apt-get -y install maven
 apt-get -y install tomcat7 tomcat7-admin
 usermod -a -G tomcat7 vagrant
 sed -i '$i<user username="islandora" password="islandora" roles="manager-gui"/>' /etc/tomcat7/tomcat-users.xml
-
-# Set JAVA_HOME -- Java8 set-default does not seem to do this.
-sed -i 's|#JAVA_HOME=/usr/lib/jvm/openjdk-6-jdk|JAVA_HOME=/usr/lib/jvm/java-8-oracle|g' /etc/default/tomcat7
 
 # Wget and curl
 apt-get -y install wget curl


### PR DESCRIPTION
Sets JAVA_HOME for the system, not just for Tomcat, and exports it in the build so we don't get the JAVA_HOME not set warnings.
