### PR TITLE
removed generic vmware base box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,13 +25,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     vb.customize ["modifyvm", :id, "--cpus", "2"]   
   end
 
-  config.vm.provider "vmware_fusion" do |v, override|
-    override.vm.box = "phusion/ubuntu-14.04-amd64"
-    override.vm.box_url = "https://oss-binaries.phusionpassenger.com/vagrant/boxes/latest/ubuntu-14.04-amd64-vmwarefusion.box"
-
-    v.vmx["memsize"] = "3000"
-    v.vmx["numvcpus"] = "2"
-  end
 
   shared_dir = "/vagrant"
 


### PR DESCRIPTION
now that we're using a custom base box,  a generic vmware basebox doesn't make sense here.
