### PR TITLE
#120: Adds permissions for anon/authed users to view objects

### DIFF
--- a/scripts/post.sh
+++ b/scripts/post.sh
@@ -7,3 +7,8 @@ service tomcat7 restart
 
 # Set correct permissions on sites/default/files
 chmod -R 775 /var/www/drupal/sites/default/files
+
+# Allow anonymous & authenticated users to view repository objects
+drush --root=/var/www/drupal role-add-perm "anonymous user" "view fedora repository objects"
+drush --root=/var/www/drupal role-add-perm "authenticated user" "view fedora repository objects"
+drush --root=/var/www/drupal cc all


### PR DESCRIPTION
This adds some drush commands to scripts/post.sh to grant anonymous users and authenticated users the "view fedora repository objects" permission (required to see any Islandora objects, including collections).

This should satisfy #120.