### PR TITLE
add directory path shortcuts

### DIFF
--- a/scripts/post.sh
+++ b/scripts/post.sh
@@ -19,6 +19,12 @@ drush --root=/var/www/drupal cc all
 # Lets brand this a bit
 
 cat <<'EOT' >> /home/vagrant/.bashrc
+export DOWNLOAD_DIR="$SHARED_DIR/downloads"
+export DJATOKA_HOME="/usr/local/djatoka"
+export FEDORA_HOME="/usr/local/fedora"
+export FITS_HOME="/usr/local/fits"
+export SOLR_HOME="/usr/local/solr"
+export DRUPAL_HOME="/var/www/drupal"
 
 echo '┌----------------------------------------------------------------------┐'
 echo '| Welcome to the Islandora 7.x Development box. Islandora is at        |'

--- a/scripts/post.sh
+++ b/scripts/post.sh
@@ -19,12 +19,11 @@ drush --root=/var/www/drupal cc all
 # Lets brand this a bit
 
 cat <<'EOT' >> /home/vagrant/.bashrc
-export DOWNLOAD_DIR="$SHARED_DIR/downloads"
-export DJATOKA_HOME="/usr/local/djatoka"
-export FEDORA_HOME="/usr/local/fedora"
-export FITS_HOME="/usr/local/fits"
-export SOLR_HOME="/usr/local/solr"
-export DRUPAL_HOME="/var/www/drupal"
+
+# Adds path variables to vagrant user
+if [ -f /vagrant/configs/variables ]; then
+    . /vagrant/configs/variables
+fi
 
 echo '┌----------------------------------------------------------------------┐'
 echo '| Welcome to the Islandora 7.x Development box. Islandora is at        |'


### PR DESCRIPTION
**JIRA Ticket**: N/A

* Corrects the issue https://github.com/Islandora-Labs/islandora_vagrant/issues/137

# What does this Pull Request do?

Adds the path shortcuts to the .bashrc file

# What's new?
### Added to .bashrc
```.bashrc
export DOWNLOAD_DIR="$SHARED_DIR/downloads"
export DJATOKA_HOME="/usr/local/djatoka"
export FEDORA_HOME="/usr/local/fedora"
export FITS_HOME="/usr/local/fits"
export SOLR_HOME="/usr/local/solr"
export DRUPAL_HOME="/var/www/drupal"
```

# How should this be tested?

Run this before switching to this PR and again after you switch to this PR and `vagrant destroy -f && vagrant up`

```terminal
$ vagrant ssh
$ cd $DRUPAL_HOME
$ pwd
$ /var/www/drupal

```

# Additional Notes:
N/A

# Interested parties
Tag (@ mention) interested parties or, if unsure, @Islandora-Labs/committers
