### PR TITLE
Force Vagrant 2.0.3 /Hashicorp new domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ N.B. This virtual machine **should not** be used in production.
 1. [VirtualBox](https://www.virtualbox.org/)
   * Be sure to install a version of VirtualBox that [is compatible with Vagrant](https://www.vagrantup.com/docs/virtualbox/)
 2. [Vagrant](http://www.vagrantup.com)
+  * Important: be sure to install Vagrant version 2.0.3 or higher
+  * If upgrading from a previus version run ```bash vagrant plugin update``` to avoid plugin issues
 3. [git](https://git-scm.com/)
 
 Note that virtualization must be enabled in the host machine's BIOS settings.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,6 +9,7 @@ $memory = ENV.fetch("ISLANDORA_VAGRANT_MEMORY", "3000")
 $hostname = ENV.fetch("ISLANDORA_VAGRANT_HOSTNAME", "islandora")
 $forward = ENV.fetch("ISLANDORA_VAGRANT_FORWARD", "TRUE")
 
+Vagrant.require_version ">= 2.0.3"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # All Vagrant configuration is done here. The most common configuration
   # options are documented and commented below. For a complete reference,


### PR DESCRIPTION
Hashicorp moved all hosted base boxes to a new domain. 
Vagrant Version 2.0.3+ is needed to be able to update base boxes. 
This pull forces that version constraint and includes info about that to the README file.

Release 7.x-1.11 branch sister pull coming in 3 minutes

# Interested parties
@rosiel @DonRichards @Islandora-Labs/committers
