### PR TITLE
Markdown issue 7.x-1.11: inline language did not work as expected

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ N.B. This virtual machine **should not** be used in production.
   * Be sure to install a version of VirtualBox that [is compatible with Vagrant](https://www.vagrantup.com/docs/virtualbox/)
 2. [Vagrant](http://www.vagrantup.com)
   * Important: be sure to install Vagrant version 2.0.3 or higher
-  * If upgrading from a previus version run ```bash vagrant plugin update``` to avoid plugin issues
+  * If upgrading from a previus version run ```vagrant plugin update``` to avoid plugin issues
 3. [git](https://git-scm.com/)
 
 Note that virtualization must be enabled in the host machine's BIOS settings.


### PR DESCRIPTION
Minor (code task?): I used `bash` for inline, single line, code and it
did not work out as expected. Basically the word `bash` is shown, so removing. My fault for being creative...
Was also fixed  on open Pull request #144  

# Interested parties
@rosiel @DonRichards 