### PR TITLE
Enables cantaloupe for Islandora modules that use IIIF

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,8 +23,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Every Vagrant virtual environment requires a box to build off of.
   config.vm.box = "islandora/islandora-base"
   
-  # This is a RC VM, So make sure people are running the latest base box by Oct 2017
-   config.vm.box_version = "~> 1.0.5"
+  # This is a RC VM, So make sure people are running the latest base box by April 2018
+  # Which will include cantaloupe IIIF Image Server
+   config.vm.box_version = "~> 1.0.6"
    config.vm.box_check_update = true
 
   unless  $forward.eql? "FALSE"  

--- a/configs/variables
+++ b/configs/variables
@@ -19,3 +19,6 @@ SOLR_HOME="/usr/local/solr"
 SOLR_VERSION=4.10.4
 
 DRUPAL_HOME="/var/www/drupal"
+
+# Uncomment next line to enable 
+# CANTALOUPE_SETUP="TRUE"

--- a/configs/variables
+++ b/configs/variables
@@ -20,5 +20,5 @@ SOLR_VERSION=4.10.4
 
 DRUPAL_HOME="/var/www/drupal"
 
-# Uncomment next line to enable 
+# Uncomment next line to enable Cantaloupe as Image Server
 # CANTALOUPE_SETUP="TRUE"

--- a/scripts/post.sh
+++ b/scripts/post.sh
@@ -18,7 +18,7 @@ drush --root=/var/www/drupal cc all
 
 
 # Config cantaloupe 
-export CANTALOUPE_RUNNING=$(curl -Is -m 10 http://127.0.0.1:8080/cantaloupe | head -n 1)
+export CANTALOUPE_RUNNING=$(curl -Is -m 10 http://127.0.0.1:8080/cantaloupe/iiif/2 | head -n 1)
 
 if [ "$CANTALOUPE_RUNNING" -eq "HTTP/1.1 200 OK" ] && [ "$CANTALOUPE_SETUP" -eq "TRUE" ] ; then
 

--- a/scripts/post.sh
+++ b/scripts/post.sh
@@ -36,6 +36,7 @@ fi
 
 # Adds path variables to vagrant user
 if [ -f /vagrant/configs/variables ]; then
+# shellcheck disable=SC1091
     . /vagrant/configs/variables
 fi
 

--- a/scripts/post.sh
+++ b/scripts/post.sh
@@ -18,10 +18,10 @@ drush --root=/var/www/drupal cc all
 
 
 # Config cantaloupe 
-CANTALOUPE_RESPONSE=$(curl -Is -m 10 http://127.0.0.1:8080/cantaloupe/iiif/2 | head -n 1 | tr -dc '[:alnum:]')
+CANTALOUPE_RESPONSE=$(sleep 10 && curl -Is -o /dev/null -m 10 -w '%{http_code}\n' 'http://127.0.0.1:8080/cantaloupe/iiif/2' | tr -dc '[:alnum:]')
 export CANTALOUPE_RUNNING="$CANTALOUPE_RESPONSE"
 
-if [ "$CANTALOUPE_RUNNING" = "HTTP11200OK" ] && [ "$CANTALOUPE_SETUP" = "TRUE" ] ; then
+if [ "$CANTALOUPE_RUNNING" = "200" ] && [ "$CANTALOUPE_SETUP" = "TRUE" ] ; then
 
     drush --root=/var/www/drupal vset islandora_openseadragon_tilesource 'iiif'
     drush --root=/var/www/drupal vset islandora_openseadragon_iiif_url 'http://localhost:8000/iiif/2'

--- a/scripts/post.sh
+++ b/scripts/post.sh
@@ -18,10 +18,10 @@ drush --root=/var/www/drupal cc all
 
 
 # Config cantaloupe 
-CANTALOUPE_RESPONSE=$(curl -Is -m 10 http://127.0.0.1:8080/cantaloupe/iiif/2 | head -n 1)
+CANTALOUPE_RESPONSE=$(curl -Is -m 10 http://127.0.0.1:8080/cantaloupe/iiif/2 | head -n 1 | tr -dc '[:alnum:]')
 export CANTALOUPE_RUNNING="$CANTALOUPE_RESPONSE"
 
-if [ "$CANTALOUPE_RUNNING" = "HTTP/1.1 200 OK" ] && [ "$CANTALOUPE_SETUP" = "TRUE" ] ; then
+if [ "$CANTALOUPE_RUNNING" = "HTTP11200OK" ] && [ "$CANTALOUPE_SETUP" = "TRUE" ] ; then
 
     drush --root=/var/www/drupal vset islandora_openseadragon_tilesource 'iiif'
     drush --root=/var/www/drupal vset islandora_openseadragon_iiif_url 'http://localhost:8000/iiif/2'

--- a/scripts/post.sh
+++ b/scripts/post.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Adds path variables to vagrant user
+if [ -f /vagrant/configs/variables ]; then
+# shellcheck disable=SC1091
+    . /vagrant/configs/variables
+fi
+
 # Setup a user for Tomcat Manager
 sed -i '$i<role rolename="admin-gui"/>' /etc/tomcat7/tomcat-users.xml
 sed -i '$i<user username="islandora" password="islandora" roles="manager-gui,admin-gui"/>' /etc/tomcat7/tomcat-users.xml
@@ -32,12 +38,6 @@ if [ "$CANTALOUPE_RUNNING" = "200" ] && [ "$CANTALOUPE_SETUP" = "TRUE" ] ; then
     drush --root=/var/www/drupal vset islandora_internet_archive_bookreader_iiif_url 'http://localhost:8000/iiif/2'
     drush --root=/var/www/drupal vset islandora_internet_archive_bookreader_iiif_token_header 1
     drush --root=/var/www/drupal vset islandora_internet_archive_bookreader_pagesource 'iiif'
-fi
-
-# Adds path variables to vagrant user
-if [ -f /vagrant/configs/variables ]; then
-# shellcheck disable=SC1091
-    . /vagrant/configs/variables
 fi
 
 # Lets brand this a bit

--- a/scripts/post.sh
+++ b/scripts/post.sh
@@ -22,16 +22,15 @@ export CANTALOUPE_RUNNING=$(curl -Is -m 10 http://127.0.0.1:8080/cantaloupe/iiif
 
 if [ "$CANTALOUPE_RUNNING" = "HTTP/1.1 200 OK" ] && [ "$CANTALOUPE_SETUP" = "TRUE" ] ; then
 
-    drush --root=/var/www/drupal vset islandora_openseadragon_tilesource iiif
-    drush --root=/var/www/drupal vset islandora_openseadragon_iiif_url http://localhost:8000/iiif/2
-    drush --root=/var/www/drupal vget islandora_openseadragon_iiif_token_header
+    drush --root=/var/www/drupal vset islandora_openseadragon_tilesource 'iiif'
+    drush --root=/var/www/drupal vset islandora_openseadragon_iiif_url 'http://localhost:8000/iiif/2'
     drush --root=/var/www/drupal vset islandora_openseadragon_iiif_token_header 1
-    drush --root=/var/www/drupal vset islandora_openseadragon_iiif_identifier [islandora_openseadragon:pid]~[islandora_openseadragon:dsid]~[islandora_openseadragon:token]
+    drush --root=/var/www/drupal vset islandora_openseadragon_iiif_identifier '[islandora_openseadragon:pid]~[islandora_openseadragon:dsid]~[islandora_openseadragon:token]'
 
-    drush --root=/var/www/drupal vset islandora_internet_archive_bookreader_iiif_identifier [islandora_iareader:pid]~[islandora_iareader:dsid]~[islandora_iareader:token]
-    drush --root=/var/www/drupal vset islandora_internet_archive_bookreader_iiif_url http://localhost:8000/iiif/2
+    drush --root=/var/www/drupal vset islandora_internet_archive_bookreader_iiif_identifier '[islandora_iareader:pid]~[islandora_iareader:dsid]~[islandora_iareader:token]'
+    drush --root=/var/www/drupal vset islandora_internet_archive_bookreader_iiif_url 'http://localhost:8000/iiif/2'
     drush --root=/var/www/drupal vset islandora_internet_archive_bookreader_iiif_token_header 1
-    drush --root=/var/www/drupal vset islandora_internet_archive_bookreader_pagesource iiif
+    drush --root=/var/www/drupal vset islandora_internet_archive_bookreader_pagesource 'iiif'
 fi
 
 # Adds path variables to vagrant user

--- a/scripts/post.sh
+++ b/scripts/post.sh
@@ -16,14 +16,32 @@ drush --root=/var/www/drupal role-add-perm "anonymous user" "view fedora reposit
 drush --root=/var/www/drupal role-add-perm "authenticated user" "view fedora repository objects"
 drush --root=/var/www/drupal cc all
 
-# Lets brand this a bit
 
-cat <<'EOT' >> /home/vagrant/.bashrc
+# Config cantaloupe 
+export CANTALOUPE_RUNNING=$(curl -Is -m 10 http://127.0.0.1:8080/cantaloupe | head -n 1)
+
+if [ "$CANTALOUPE_RUNNING" -eq "HTTP/1.1 200 OK" ] && [ "$CANTALOUPE_SETUP" -eq "TRUE" ] ; then
+
+    drush --root=/var/www/drupal vset islandora_openseadragon_tilesource iiif
+    drush --root=/var/www/drupal vset islandora_openseadragon_iiif_url http://localhost:8000/iiif/2
+    drush --root=/var/www/drupal vget islandora_openseadragon_iiif_token_header
+    drush --root=/var/www/drupal vset islandora_openseadragon_iiif_token_header 1
+    drush --root=/var/www/drupal vset islandora_openseadragon_iiif_identifier [islandora_openseadragon:pid]~[islandora_openseadragon:dsid]~[islandora_openseadragon:token]
+
+    drush --root=/var/www/drupal vset islandora_internet_archive_bookreader_iiif_identifier [islandora_iareader:pid]~[islandora_iareader:dsid]~[islandora_iareader:token]
+    drush --root=/var/www/drupal vset islandora_internet_archive_bookreader_iiif_url http://localhost:8000/iiif/2
+    drush --root=/var/www/drupal vset islandora_internet_archive_bookreader_iiif_token_header 1
+    drush --root=/var/www/drupal vset islandora_internet_archive_bookreader_pagesource iiif
+fi
 
 # Adds path variables to vagrant user
 if [ -f /vagrant/configs/variables ]; then
     . /vagrant/configs/variables
 fi
+
+# Lets brand this a bit
+
+cat <<'EOT' >> /home/vagrant/.bashrc
 
 echo '┌----------------------------------------------------------------------┐'
 echo '| Welcome to the Islandora 7.x Development box. Islandora is at        |'

--- a/scripts/post.sh
+++ b/scripts/post.sh
@@ -18,7 +18,8 @@ drush --root=/var/www/drupal cc all
 
 
 # Config cantaloupe 
-export CANTALOUPE_RUNNING=$(curl -Is -m 10 http://127.0.0.1:8080/cantaloupe/iiif/2 | head -n 1)
+CANTALOUPE_RESPONSE=$(curl -Is -m 10 http://127.0.0.1:8080/cantaloupe/iiif/2 | head -n 1)
+export CANTALOUPE_RUNNING="$CANTALOUPE_RESPONSE"
 
 if [ "$CANTALOUPE_RUNNING" = "HTTP/1.1 200 OK" ] && [ "$CANTALOUPE_SETUP" = "TRUE" ] ; then
 

--- a/scripts/post.sh
+++ b/scripts/post.sh
@@ -20,7 +20,7 @@ drush --root=/var/www/drupal cc all
 # Config cantaloupe 
 export CANTALOUPE_RUNNING=$(curl -Is -m 10 http://127.0.0.1:8080/cantaloupe/iiif/2 | head -n 1)
 
-if [ "$CANTALOUPE_RUNNING" -eq "HTTP/1.1 200 OK" ] && [ "$CANTALOUPE_SETUP" -eq "TRUE" ] ; then
+if [ "$CANTALOUPE_RUNNING" = "HTTP/1.1 200 OK" ] && [ "$CANTALOUPE_SETUP" = "TRUE" ] ; then
 
     drush --root=/var/www/drupal vset islandora_openseadragon_tilesource iiif
     drush --root=/var/www/drupal vset islandora_openseadragon_iiif_url http://localhost:8000/iiif/2


### PR DESCRIPTION
# What does this Pull Request do?

Enables automatic setup of Cantaloupe if desired so. Requires uncommenting a line inside /config/variables and using a base box that contains https://github.com/Islandora-Labs/islandora_vagrant_base_box/pull/31

# What's new?
Openseadragon and IABR will be ready to use Cantaloupe and IIIF settings.

# How should this be tested?

use a new base box with https://github.com/Islandora-Labs/islandora_vagrant_base_box/pull/31, 

uncomment [this line]( https://github.com/DiegoPino/islandora_vagrant/blob/26dd89fe0b877b9c405ef9da3fb0242012b6e672/configs/variables#L24 )

 a  `vagrant up`

Add a large image, see if it can be displayed,

Also, fixes an issue with a previous pull where ENV variables got mixed with a /home/vagrant/.bashrc output.

# Interested parties
@lutaylor, @rosiel, @DonRichards