### PR TITLE
Updates required base box to 1.0.9

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,7 +25,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   
   # This is a RC VM, So make sure people are running the latest base box by April 2018
   # Which will include cantaloupe IIIF Image Server
-   config.vm.box_version = "1.0.7"
+   config.vm.box_version = "1.0.9"
    config.vm.box_check_update = true
 
   unless  $forward.eql? "FALSE"  


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2372

Also related to https://github.com/Islandora-Labs/islandora_vagrant/issues/161

# What does this Pull Request do?
Updates the Vagrantfile's required base box version to the new 1.0.9 box.

# How should this be tested?
Boot with 7.x branch and check /etc/ImageMagic/policy.xml and see that the settings at the bottom don't afford PDF derivative creation. Switch to this PR and rebuild the machine to see that it downloads a new base box with /etc/ImageMagic/policy.xml udpated.

# Interested parties
@bondjimbond @DonRichards @dannylamb 
