### PR TITLE
Prepare for Islandora 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ $ vagrant plugin install vagrant-vbguest
 $ vagrant plugin install vagrant-hostsupdater
 ```
 To start this as a second VM either:
-* set a enviroment variable ISLANDORA_VAGRANT_MULTIPLE_ISLANDORAS or
-* run the following command: ISLANDORA_VAGRANT_MULTIPLE_ISLANDORAS='TRUE' vagrant up
+* set a enviroment variable `ISLANDORA_VAGRANT_MULTIPLE_ISLANDORAS` or
+* run the following command: `ISLANDORA_VAGRANT_MULTIPLE_ISLANDORAS='TRUE' vagrant up`
 
 You will be asked to enter your local user password. When Vagrant stops running, Islandora 7.x will be available at http://33.33.33.10:8000.
 ```shell

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ export ISLANDORA_VAGRANT_FORWARD="FALSE"
 
 ## Connect
 
-Note: The supplied links apply only to this local vagrant system. They could vary in other installations. 
+Note: The supplied links apply only to this local vagrant system. They could vary in other installations.
 
 You can connect to the machine via the browser at [http://localhost:8000](http://localhost:8000).
 
@@ -101,9 +101,9 @@ ssh, scp, rsync:
 - jQuery 1.10.2
 
 ## Run in a multiple VM configuration
-To run this vm side by side with Islandora 8 or another VM with conflicting ports do the following
+To run this vm side by side with Islandora 8 or another VM with conflicting ports do the following.
 
-Prerequisite vagrant plugins for full operation.
+To use this configuration, you must install two Vagrant plugins.
 ```shell
   # For more info https://github.com/dotless-de/vagrant-vbguest
 $ vagrant plugin install vagrant-vbguest
@@ -111,7 +111,11 @@ $ vagrant plugin install vagrant-vbguest
   # For more info https://github.com/cogitatio/vagrant-hostsupdater
 $ vagrant plugin install vagrant-hostsupdater
 ```
-To start this as a second VM either set a enviroment variable `ISLANDORA_VAGRANT_MULTIPLE_ISLANDORAS` to TRUE or run the following command.
+To start this as a second VM either:
+* set a enviroment variable ISLANDORA_VAGRANT_MULTIPLE_ISLANDORAS or
+* run the following command: ISLANDORA_VAGRANT_MULTIPLE_ISLANDORAS='TRUE' vagrant up
+
+You will be asked to enter your local user password. When Vagrant stops running, Islandora 7.x will be available at http://33.33.33.10:8000.
 ```shell
 $ ISLANDORA_VAGRANT_MULTIPLE_ISLANDORAS='TRUE' vagrant up
 ```
@@ -130,7 +134,7 @@ $ ISLANDORA_VAGRANT_MULTIPLE_ISLANDORAS='TRUE' vagrant up
 ::1             localhost
 33.33.33.10  islandora  # VAGRANT: 67ed63b757392fOOc6a4e5Od8a6b6428 (default) / 7d727ed8-557g-4be8-9e13-589444a57754
 ```
-
+Also note that each vm must be halted separately, from within the directories on the host where they were started with vagrant up.
 
 ## Maintainers
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,38 @@ ssh, scp, rsync:
 - drush 6.3.0
 - jQuery 1.10.2
 
+## Run in a multiple VM configuration
+To run this vm side by side with Islandora 8 or another VM with conflicting ports do the following
+
+Prerequisite vagrant plugins for full operation.
+```shell
+  # For more info https://github.com/dotless-de/vagrant-vbguest
+$ vagrant plugin install vagrant-vbguest
+
+  # For more info https://github.com/cogitatio/vagrant-hostsupdater
+$ vagrant plugin install vagrant-hostsupdater
+```
+To start this as a second VM either set a enviroment variable `ISLANDORA_VAGRANT_MULTIPLE_ISLANDORAS` to TRUE or run the following command.
+```shell
+$ ISLANDORA_VAGRANT_MULTIPLE_ISLANDORAS='TRUE' vagrant up
+```
+
+#### NOTE:
+`vagrant-hostsupdater` will temporarily update the host machine's `/etc/hosts` file and remove it when vagrant is destroyed.
+```txt
+##
+# Host Database
+#
+# localhost is used to configure the loopback interface
+# when the system is booting.  Do not change this entry.
+##
+127.0.0.1       localhost
+255.255.255.255 broadcasthost
+::1             localhost
+33.33.33.10  islandora  # VAGRANT: 67ed63b757392fOOc6a4e5Od8a6b6428 (default) / 7d727ed8-557g-4be8-9e13-589444a57754
+```
+
+
 ## Maintainers
 
 * [Don Richards](https://github.com/donrichards)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,6 +8,7 @@ $cpus   = ENV.fetch("ISLANDORA_VAGRANT_CPUS", "2")
 $memory = ENV.fetch("ISLANDORA_VAGRANT_MEMORY", "3000")
 $hostname = ENV.fetch("ISLANDORA_VAGRANT_HOSTNAME", "islandora")
 $forward = ENV.fetch("ISLANDORA_VAGRANT_FORWARD", "TRUE")
+$multiple_vms  = ENV.fetch("ISLANDORA_VAGRANT_MULTIPLE_ISLANDORAS", "FALSE")
 
 Vagrant.require_version ">= 2.0.3"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
@@ -22,16 +23,23 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # Every Vagrant virtual environment requires a box to build off of.
   config.vm.box = "islandora/islandora-base"
-  
+
   # This is a RC VM, So make sure people are running the latest base box by April 2018
   # Which will include cantaloupe IIIF Image Server
    config.vm.box_version = "1.0.9"
    config.vm.box_check_update = true
 
-  unless  $forward.eql? "FALSE"  
-    config.vm.network :forwarded_port, guest: 8080, host: 8080 # Tomcat
-    config.vm.network :forwarded_port, guest: 3306, host: 3306 # MySQL
-    config.vm.network :forwarded_port, guest: 8000, host: 8000 # Apache
+  # This checks and updates VirtualBox Guest Additions.
+   if Vagrant.has_plugin?("vagrant-vbguest")
+    config.vbguest.auto_update = true
+    config.vbguest.no_remote = false
+   end
+
+  unless  $forward.eql? "FALSE"
+    config.vm.network :forwarded_port, guest: 8080, host: 8080, id: 'Tomcat', auto_correct: true
+    config.vm.network :forwarded_port, guest: 3306, host: 3306, id: 'MySQL', auto_correct: true
+    config.vm.network :forwarded_port, guest: 8000, host: 8000, id: 'Apache', auto_correct: true
+    config.vm.network :forwarded_port, guest: 22, host: 2222, id: "ssh", auto_correct: true
   end
 
   config.vm.provider "virtualbox" do |vb|
@@ -40,6 +48,14 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   shared_dir = "/vagrant"
+  # Moves Islandora 7.x to ipaddress instead of localhost.
+  unless  $multiple_vms.eql? "FALSE"
+     unless Vagrant.has_plugin?("vagrant-hostsupdater")
+       raise 'vagrant-hostsupdater is not installed!'
+     end
+     config.vm.network :private_network, ip: "33.33.33.10"
+
+   end
 
   config.vm.provision :shell, path: "./scripts/islandora_modules.sh", :args => shared_dir, :privileged => false
   config.vm.provision :shell, path: "./scripts/islandora_libraries.sh", :args => shared_dir, :privileged => false
@@ -47,4 +63,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.provision :shell, path: "./scripts/custom.sh", :args => shared_dir
   end
   config.vm.provision :shell, path: "./scripts/post.sh"
+
+  unless  $multiple_vms.eql? "FALSE"
+    # Fires last to modify one last change.
+    config.vm.provision "this",
+    type: "shell",
+    preserve_order: true,
+    inline: "cd /var/www/drupal && /usr/bin/drush vset islandora_paged_content_djatoka_url 'http://33.33.33.10:8080/adore-djatoka'"
+  end
 end


### PR DESCRIPTION
**JIRA Ticket**: N/A

# What does this Pull Request do?
Allows for Islandora vagrant to run side by side with another vagrant (with conflicting ports) but still allows full functionality. 

# What's new?
Instead of using localhost:8000 to get to the VM, it's using 33.33.33.10:8000

Because of the order of operation it appears to assign ports before moving the address to 33.33.33.10. All of the ports shift to 220x number first and then revert once the IP is established. 
This is why all of the ports have ", auto_correct: true" now. They still show as 220x in terminal but the browser sees them as the original ports (8000, 8080, 3306).

Adding port "ID" is a generic improvement. 

vagrant-hostsupdater is essential for the IP address forwarding. This adds a check to see if the vagrant plugin is installed and warns if it isn't.

To theoretically improve stability and performance the GuestAdditions versions should match. 
Example Message: `GuestAdditions versions on your host (6.0.8) and guest (5.1.38) do not match`
This downloads and installs the updated "VBoxGuestAdditions" into the VM prior to building. 

# How should this be tested?
1. Run as a stand alone (no other VMs running) with the typical `vagrant up` and check nothing is wrong localhost:8000 as usual.

2. Destroy VM once all checks are done. `vagrant destroy -f`

3. Next, start Islandora 8 up. After Islandora 8 has booted, start islandora_vagrant just like the instructions say in the "Run in a multiple VM configuration" section on the README file. 

##### NOTE: The only reason why Islandora 8 VM needs to be running in the background is to cause a port conflict during the boot process for this VM. 

Short description:
```shell
$ ISLANDORA_VAGRANT_MULTIPLE_ISLANDORAS='TRUE' vagrant up
```

a. Run ingests on any content model that might be impacted by a port change (large image, book, video, etc).
b. Verify nothing breaks.

# Additional Notes:
The documentation should reflect all of these changes.

If this VM is booted without setting  **ISLANDORA_VAGRANT_MULTIPLE_ISLANDORAS** provision by mistake, run 'this'.
```shell
$ ISLANDORA_VAGRANT_MULTIPLE_ISLANDORAS='TRUE' vagrant reload --provision-with this

# OR

$ vagrant halt && ISLANDORA_VAGRANT_MULTIPLE_ISLANDORAS='TRUE' vagrant up --provision-with this
```

If this VM is booted without the second VM already running, just vagrant halt and vagrant up and it will reset.
```shell
$ vagrant halt && ISLANDORA_VAGRANT_MULTIPLE_ISLANDORAS='TRUE' vagrant up
```

# Interested parties
@Islandora-Labs/committers @dannylamb @br2490 
